### PR TITLE
Add Sematell GmbH

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ PicDrop | https://www.picdrop.de | Berlin
 pimentaGROUP | https://pimentagroup.de | Münster
 porta-Unternehmensgruppe | https://porta.de | Full Remote - Offices in Aschaffenburg, Berlin, Porta Westfalica, München
 real.digital | https://www.real-digital.de | Cologne / Darmstadt
+Sematell GmbH | https://www.sematell.com | Saarbrücken
 SkedGo | https://skedgo.com/ | Nuremberg
 SocialHub | https://socialhub.io | Ingolstadt
 SocialSweethearts | https://socialsweethearts.de | Munich


### PR DESCRIPTION
Bei Sematell bieten wir die Möglichkeit flexibel zwischen On-site in Saarbrücken, Hybrid und 100% Remote Verträgen zu wählen. Bei Remote Kollegen erwarten wir lediglich die Bereitschaft zu Sommer- und Weihnachtsfeier sowie 1-2 Workshops/Schulungen im Jahr nach Saarbrücken zu reisen.